### PR TITLE
⚙️ [Maintenance]: Adopt Process-PSModule v6.1.4 and require Pester 6.x in tests

### DIFF
--- a/.github/workflows/Process-PSModule.yml
+++ b/.github/workflows/Process-PSModule.yml
@@ -27,5 +27,5 @@ permissions:
 
 jobs:
   Process-PSModule:
-    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@205d193f34cbbaf9992955c21d842bcf98a1859f # v5.4.6
+    uses: PSModule/Process-PSModule/.github/workflows/workflow.yml@da180bac16b13bfbcdf08b2e4e221b5b49e5ff28 # v6.1.4
     secrets: inherit

--- a/tests/PSModuleTest.Tests.ps1
+++ b/tests/PSModuleTest.Tests.ps1
@@ -1,4 +1,6 @@
-﻿[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
+﻿#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '6.0.0'; MaximumVersion = '6.*'; GUID = 'a699dea5-2c73-4616-a270-1f7abb777e71' }
+
+[Diagnostics.CodeAnalysis.SuppressMessageAttribute(
     'PSReviewUnusedParameter', '',
     Justification = 'Required for Pester tests'
 )]

--- a/tests/PSModuleTest.Tests.ps1
+++ b/tests/PSModuleTest.Tests.ps1
@@ -1,4 +1,4 @@
-﻿#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '6.0.0'; MaximumVersion = '6.*'; GUID = 'a699dea5-2c73-4616-a270-1f7abb777e71' }
+﻿#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '6.0.0'; MaximumVersion = '6.*' }
 
 [Diagnostics.CodeAnalysis.SuppressMessageAttribute(
     'PSReviewUnusedParameter', '',


### PR DESCRIPTION
This module now runs on the latest Process-PSModule automation (v6.1.4) and pins its test suite to Pester 6, so continuous integration uses the current build, test, and publish pipeline and the tests fail fast if Pester 6 is ever missing.

## Changed: CI runs on Process-PSModule v6.1.4

The reusable workflow pin moves to v6.1.4 from the module's previously pinned v5 release, adopting the current pipeline, including the Pester 6 test runner and the consolidated `TestData` secret model. No caller changes are required — the existing `secrets` wiring keeps passing everything the pipeline needs.

## Changed: Tests require Pester 6.x

Every test file now declares the Pester 6 requirement, so the suite always resolves Pester 6 and fails with a clear message if only an older Pester is available, instead of silently running on it.

## Technical Details

- `.github/workflows/Process-PSModule.yml`: pin bumped to `workflow.yml@da180bac16b13bfbcdf08b2e4e221b5b49e5ff28 # v6.1.4`.
- `tests/*.Tests.ps1`: added `#Requires -Modules @{ ModuleName = 'Pester'; ModuleVersion = '6.0.0'; MaximumVersion = '6.*' }`.
- Classic `Should` assertions are left unchanged. Pester 6 is backward-compatible, so converting to the new `Should-*` syntax is intentionally out of scope for this maintenance change.
- Supersedes any stale Dependabot bump of the Process-PSModule pin.
